### PR TITLE
removed ::before html element for the kill-btn

### DIFF
--- a/src/lib/components/ProcessTable.svelte
+++ b/src/lib/components/ProcessTable.svelte
@@ -376,10 +376,6 @@
     border: 1px solid color-mix(in srgb, var(--red) 30%, transparent);
   }
 
-  .kill-btn::before {
-    background: var(--red);
-  }
-
   .kill-btn:hover {
     color: var(--base);
     background: var(--red);


### PR DESCRIPTION
When I hovered on the kill-btn there was a tiny jump on the col-action tag child elements. I identified that it was caused by ::before element. It was also placing the entire button behind itself blocking the view. Removing it seems to fix both issues hence the PR