### PR TITLE
Improve support for smaller screens

### DIFF
--- a/src/lib/components/StatsBar.svelte
+++ b/src/lib/components/StatsBar.svelte
@@ -452,5 +452,6 @@
   .stat-panel:nth-child(4),
   .stat-panel:nth-child(5) {
     flex: 0.8; /* Storage, System, and Network: less space */
+    min-width: 125px;
   }
 </style>

--- a/src/lib/components/ThemeSwitcher.svelte
+++ b/src/lib/components/ThemeSwitcher.svelte
@@ -64,7 +64,6 @@
           style:background={$themeStore.colors.green}
         ></div>
       </div>
-      {$themeStore.label}
     </div>
     <span class="icon">{showMenu ? "▼" : "▶"}</span>
   </button>

--- a/src/lib/components/ToolBar.svelte
+++ b/src/lib/components/ToolBar.svelte
@@ -89,10 +89,10 @@
         >
           «
         </button>
-        <span class="page-info">
-          Page {currentPage} of {totalPages}
+        <div class="page-info">
+          <span>Page {currentPage} of {totalPages}</span>
           <span class="results-info">({totalResults} processes)</span>
-        </span>
+        </div>
         <button
           class="btn-page"
           disabled={currentPage === totalPages}
@@ -109,6 +109,7 @@
         </button>
       </div>
     </div>
+    <div class="toolbar-spacer"></div>
 
     <div class="column-toggle">
       <button
@@ -297,8 +298,13 @@
     font-size: 12px;
     color: var(--subtext0);
     display: flex;
+    flex-direction: column;
     align-items: center;
-    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  .page-info span {
+    display: block;
   }
 
   .results-info {

--- a/src/lib/components/ToolBar.svelte
+++ b/src/lib/components/ToolBar.svelte
@@ -46,20 +46,11 @@
     <div class="search-box">
       <div class="search-input-wrapper">
         <input
-          type="text"
+          type="search"
           placeholder="Search processes"
           bind:value={searchTerm}
           class="search-input"
         />
-        {#if searchTerm}
-          <button
-            class="btn-clear"
-            on:click={() => (searchTerm = "")}
-            title="Clear search"
-          >
-            Clear
-          </button>
-        {/if}
       </div>
     </div>
     <div class="toolbar-group">


### PR DESCRIPTION
Related to #23 some UI changes that make neohtop work better with smaller window widths.

- Storage, System and Network stat panel have a minimum width of 150px. This prevents issue where text would get wrapped and items cut off. The CPU and memory panels shrink more in these cases, making the usage bars smaller
- removed the theme name from the theme switcher button. I like the switcher button, but I feel like having the 3 colors show your theme already does a good job of displaying the active theme.
- use the standard/system clear button that is available for input with the `search` type to not need the extra clear button.
- Stack the "Page X of Y" and "(x processes)" labels. They actually fit without making the toolbar higher, saving quite a bit of vertical space
- center the pagination

These are more just suggestions from me and I can also undo some of the changes if the old style is preferred for p.e. the theme switcher.

New possible minimum width of around 1100px:
![Screenshot 2024-11-08 at 12 18 55](https://github.com/user-attachments/assets/b84370d9-f097-4e1e-bdca-0bf541ef8b08)

with a wider window to show the centering:
![Screenshot 2024-11-08 at 12 18 59](https://github.com/user-attachments/assets/c27f2765-7598-40dc-b5ac-76c288a9167e)
