### PR TITLE
Search processes with comma-separated queries, incl regexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@
 - 💻 CPU and Memory usage tracking
 - 🎨 Beautiful, modern UI with dark/light themes
 - 🔍 Process search and filtering
+
+  Search for processes by name, command, or PID. Search for multiple things at once by separating them with commas. For
+  example, `arm, x86` will return processes having `arm` or `x86` as a substring of the name or command. You can use
+  regular expressions too. For example, `d$` will return a list of daemons (which tend to end in the letter `d`), while
+  `(\w+)\.\w+` will return a list of processes with reverse domain name notation, such as `com.docker.vmnetd`.
+
 - 📌 Pin important processes
 - 🛠 Process management (kill processes)
 - 🎯 Sort by any column

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -60,11 +60,22 @@
   };
 
   $: filteredProcesses = processes.filter((process) => {
-    const matchesSearch = searchTerm
-      ? process.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        process.command.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        process.pid.toString().includes(searchTerm)
-      : true;
+    let matchesSearch = searchTerm.length === 0;
+    searchTerm
+      .split(",")
+      .map((term) => term.trim())
+      .forEach((term) => {
+        const nameSubstringMatch = process.name
+          .toLowerCase()
+          .includes(term.toLowerCase());
+        const nameRegexMatch = new RegExp(term, "i").test(process.name);
+        const commandMatch = process.command
+          .toLowerCase()
+          .includes(term.toLowerCase());
+        const pidMatch = process.pid.toString().includes(term);
+        matchesSearch ||=
+          nameSubstringMatch || nameRegexMatch || commandMatch || pidMatch;
+      });
 
     const matchesStatus =
       statusFilter === "all" ? true : process.status === statusFilter;


### PR DESCRIPTION
## Description

This PR makes search more powerful.
* The user may search with multiple terms at the same time by separating them with commas. E.g. `arm, x86` will match any process which includes `arm` or `x86` as a substring. (Whitespace is trimmed.)
* The user may search with regular expressions. E.g. `d$` returns a list of system daemons (which often end with `d`).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Just manual testing. YOLO!

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 