### PR TITLE
Search fails on invalid regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   Search for processes by name, command, or PID. Search for multiple things at once by separating them with commas. For
   example, `arm, x86` will return processes having `arm` or `x86` as a substring of the name or command. You can use
   regular expressions too. For example, `d$` will return a list of daemons (which tend to end in the letter `d`), while
-  `(\w+)\.\w+` will return a list of processes with reverse domain name notation, such as `com.docker.vmnetd`.
+  `^(\w+\.)+\w+$` will return a list of processes with reverse domain name notation, such as `com.docker.vmnetd`.
 
 - 📌 Pin important processes
 - 🛠 Process management (kill processes)

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -68,7 +68,13 @@
         const nameSubstringMatch = process.name
           .toLowerCase()
           .includes(term.toLowerCase());
-        const nameRegexMatch = new RegExp(term, "i").test(process.name);
+        const nameRegexMatch = (() => {
+          try {
+            return new RegExp(term, "i").test(process.name);
+          } catch {
+            return false;
+          }
+        })();
         const commandMatch = process.command
           .toLowerCase()
           .includes(term.toLowerCase());


### PR DESCRIPTION
## Description

Oops, [my recent PR](https://github.com/Abdenasser/neohtop/pull/60) introduced a bug where, if a user types a search string that is an invalid regex, the filter fails to be applied. Instead, the other kinds of matching like substring matching should still be performed. For example, PR 60 broke the search for `(`. This PR fixes that.

This PR also corrects a typo in the README related to regex search.

## Type of change

[x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual testing.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 