### PR TITLE
Add network usage monitoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "macos-task-manager",
-  "version": "1.0.5",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "macos-task-manager",
-      "version": "1.0.5",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.6.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1610,6 +1610,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 name = "macos-task-manager"
 version = "1.0.8"
 dependencies = [
+ "regex",
  "serde",
  "serde_json",
  "sysinfo",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "2", features = [] }
 sysinfo = "0.29.0"
+regex = "1.11.1"
 
 [features]
 default = [ "custom-protocol" ]

--- a/src/lib/components/StatsBar.svelte
+++ b/src/lib/components/StatsBar.svelte
@@ -9,6 +9,7 @@
   } from "@fortawesome/free-solid-svg-icons";
   import type { SystemStats } from "$lib/types";
   import {
+    formatBytes,
     formatUptime,
     formatMemorySize,
     formatPercentage,
@@ -20,18 +21,6 @@
     ? (systemStats.memory_used / systemStats.memory_total) * 100
     : 0;
 
-  function formatBytes(bytes: number): string {
-    const units = ["B", "KB", "MB", "GB", "TB"];
-    let value = bytes;
-    let unitIndex = 0;
-
-    while (value >= 1024 && unitIndex < units.length - 1) {
-      value /= 1024;
-      unitIndex++;
-    }
-
-    return `${value.toFixed(1)} ${units[unitIndex]}`;
-  }
 
   $: diskUsagePercentage = systemStats
     ? (systemStats.disk_used_bytes / systemStats.disk_total_bytes) * 100

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -5,6 +5,8 @@ export interface Process {
   name: string;
   cpu_usage: number;
   memory_usage: number;
+  network_rx: number;
+  network_tx: number;
   status: string;
   user: string;
   command: string;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -39,6 +39,19 @@ export function formatMemorySize(bytes: number): string {
   return `${gb.toFixed(1)} GB`;
 }
 
+export function formatNetwork(bytes: number) {
+  // Convert bytes to either KB, MB, or GB
+  if (bytes === 0) {
+    return "0 B";
+  } else if (bytes < 1024) {
+    return (bytes / 1024).toFixed(2) + " KB";
+  } else if (bytes < 1024 * 1024 * 1024) {
+    return (bytes / (1024 * 1024)).toFixed(2) + " MB";
+  } else {
+    return (bytes / (1024 * 1024 * 1024)).toFixed(2) + " GB";
+  }
+}
+
 export function formatPercentage(value: number): string {
   return `${value.toFixed(1)}%`;
 }

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -27,6 +27,19 @@ export const statusMap: Record<string, ProcessStatus> = {
   },
 };
 
+export function formatBytes(bytes: number): string {
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let unitIndex = 0;
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+
+  return `${value.toFixed(2)} ${units[unitIndex]}`;
+}
+
 export function formatStatus(status: string): string {
   const processStatus = statusMap[status] || statusMap.Unknown;
   return `<span class="status-badge" style="--status-color: ${processStatus.color}">
@@ -37,19 +50,6 @@ export function formatStatus(status: string): string {
 export function formatMemorySize(bytes: number): string {
   const gb = bytes / (1024 * 1024 * 1024);
   return `${gb.toFixed(1)} GB`;
-}
-
-export function formatNetwork(bytes: number) {
-  // Convert bytes to either KB, MB, or GB
-  if (bytes === 0) {
-    return "0 B";
-  } else if (bytes < 1024) {
-    return (bytes / 1024).toFixed(2) + " KB";
-  } else if (bytes < 1024 * 1024 * 1024) {
-    return (bytes / (1024 * 1024)).toFixed(2) + " MB";
-  } else {
-    return (bytes / (1024 * 1024 * 1024)).toFixed(2) + " GB";
-  }
 }
 
 export function formatPercentage(value: number): string {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -50,6 +50,18 @@
       visible: true,
       format: (v) => (v / (1024 * 1024)).toFixed(1) + " MB",
     },
+    {
+      id: "network_rx",
+      label: "Network RX",
+      visible: true,
+      format: (v) => (v / (1024 * 1024)).toFixed(1) + " MB",
+    },
+    {
+      id: "network_tx",
+      label: "Network TX",
+      visible: true,
+      format: (v) => (v / (1024 * 1024)).toFixed(1) + " MB",
+    },
     { id: "command", label: "Command", visible: false },
     { id: "ppid", label: "Parent PID", visible: false },
   ];

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -54,13 +54,13 @@
       id: "network_rx",
       label: "Network RX",
       visible: true,
-      format: (v) => (v / (1024 * 1024)).toFixed(1) + " MB",
+      format: (v) => formatNetwork(v),
     },
     {
       id: "network_tx",
       label: "Network TX",
       visible: true,
-      format: (v) => (v / (1024 * 1024)).toFixed(1) + " MB",
+      format: (v) => formatNetwork(v),
     },
     { id: "command", label: "Command", visible: false },
     { id: "ppid", label: "Parent PID", visible: false },
@@ -136,6 +136,17 @@
       intervalId = setInterval(() => {
         getProcesses();
       }, refreshRate);
+    }
+  }
+
+  function formatNetwork(bytes: number) {
+    // Convert bytes to either KB, MB, or GB
+    if (bytes < 1024) {
+      return (bytes / 1024).toFixed(2) + " KB";
+    } else if (bytes < 1024 * 1024 * 1024) {
+      return (bytes / (1024 * 1024)).toFixed(2) + " MB";
+    } else {
+      return (bytes / (1024 * 1024 * 1024)).toFixed(2) + " GB";
     }
   }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
   import ProcessTable from "$lib/components/ProcessTable.svelte";
   import ProcessDetailsModal from "$lib/components/ProcessDetailsModal.svelte";
   import KillProcessModal from "$lib/components/KillProcessModal.svelte";
-  import { formatNetwork, formatStatus } from "$lib/utils";
+  import { formatBytes, formatStatus } from "$lib/utils";
   import { themeStore } from "$lib/stores";
   import type { Process, SystemStats, Column } from "$lib/types";
 
@@ -54,13 +54,13 @@
       id: "network_rx",
       label: "Network RX",
       visible: true,
-      format: (v) => formatNetwork(v),
+      format: (v) => formatBytes(v),
     },
     {
       id: "network_tx",
       label: "Network TX",
       visible: true,
-      format: (v) => formatNetwork(v),
+      format: (v) => formatBytes(v),
     },
     { id: "command", label: "Command", visible: false },
     { id: "ppid", label: "Parent PID", visible: false },

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -141,7 +141,9 @@
 
   function formatNetwork(bytes: number) {
     // Convert bytes to either KB, MB, or GB
-    if (bytes < 1024) {
+    if (bytes === 0) {
+      return "0 B";
+    } else if (bytes < 1024) {
       return (bytes / 1024).toFixed(2) + " KB";
     } else if (bytes < 1024 * 1024 * 1024) {
       return (bytes / (1024 * 1024)).toFixed(2) + " MB";

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
   import ProcessTable from "$lib/components/ProcessTable.svelte";
   import ProcessDetailsModal from "$lib/components/ProcessDetailsModal.svelte";
   import KillProcessModal from "$lib/components/KillProcessModal.svelte";
-  import { formatStatus } from "$lib/utils";
+  import { formatNetwork, formatStatus } from "$lib/utils";
   import { themeStore } from "$lib/stores";
   import type { Process, SystemStats, Column } from "$lib/types";
 
@@ -136,19 +136,6 @@
       intervalId = setInterval(() => {
         getProcesses();
       }, refreshRate);
-    }
-  }
-
-  function formatNetwork(bytes: number) {
-    // Convert bytes to either KB, MB, or GB
-    if (bytes === 0) {
-      return "0 B";
-    } else if (bytes < 1024) {
-      return (bytes / 1024).toFixed(2) + " KB";
-    } else if (bytes < 1024 * 1024 * 1024) {
-      return (bytes / (1024 * 1024)).toFixed(2) + " MB";
-    } else {
-      return (bytes / (1024 * 1024 * 1024)).toFixed(2) + " GB";
     }
   }
 


### PR DESCRIPTION
## Description

macOS's activity monitor shows how much network usage a process has - this PR starts to work on that. `nettop` is run to get the output, but it seems like it isn't very performant (and doesn't work Linux / Windows). This is to prove the concept and then we can improve it going forward

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I have run this on my machine and confirmed that it works as expected

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 