### PR TITLE
doc: add setups for mac local build

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ npm run tauri dev
 
 # Build for production
 npm run tauri build
+
+# Build for local mac(Bypass code signing)
+npm run tauri build -- --bundles app --config "{\"bundle\":{\"macOS\":{\"signingIdentity\":null}}}"
 ```
 
 ## Contributing


### PR DESCRIPTION
## Description

Provided a new commands on `README.md` which can be used on building locally on Mac machine.

This command by-passes the code signing by overriding null identity to tauri build with parameters.

Partially fixes #88 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

```shell
# before
# omit vite build
> Using @sveltejs/adapter-static
  Wrote site to "build"
  ✔ done
   Compiling macos-task-manager v1.0.8 (/Users/user/Desktop/workspace/develop/neohtop/src-tauri)
    Finished `release` profile [optimized] target(s) in 51.05s
    Built application at: /Users/user/Desktop/workspace/develop/neohtop/src-tauri/target/release/NeoHtop
    Bundling NeoHtop.app (/Users/user/Desktop/workspace/develop/neohtop/src-tauri/target/release/bundle/macos/NeoHtop.app)
    Signing with identity "Developer ID Application: Abdenasser Elidrissi (785JV74B9Y)"
Signing with identity "Developer ID Application: Abdenasser Elidrissi (785JV74B9Y)"
Signing /Users/user/Desktop/workspace/develop/neohtop/src-tauri/target/release/bundle/macos/NeoHtop.app/Contents/MacOS/NeoHtop
error: The specified item could not be found in the keychain.
failed to bundle project: failed to sign app
```

```shell
# after
# omit vite build
> Using @sveltejs/adapter-static
  Wrote site to "build"
  ✔ done
   Compiling macos-task-manager v1.0.8 (/Users/user/Desktop/workspace/develop/neohtop/src-tauri)
    Finished `release` profile [optimized] target(s) in 53.68s
    Built application at: /Users/user/Desktop/workspace/develop/neohtop/src-tauri/target/release/NeoHtop
    Bundling NeoHtop.app (/Users/user/Desktop/workspace/develop/neohtop/src-tauri/target/release/bundle/macos/NeoHtop.app)
    Finished 1 bundle at:
        /Users/user/Desktop/workspace/develop/neohtop/src-tauri/target/release/bundle/macos/NeoHtop.app
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 