### PR TITLE
Allow small widths by hiding AppInfo

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,7 +44,7 @@
         "resizable": true,
         "title": "NeoHtop",
         "width": 1280,
-        "minWidth": 1120,
+        "minWidth": 1000,
         "minHeight": 700,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,

--- a/src/lib/components/toolbar/ColumnToggle.svelte
+++ b/src/lib/components/toolbar/ColumnToggle.svelte
@@ -79,6 +79,7 @@
     border-radius: 6px;
     cursor: pointer;
     transition: all 0.2s ease;
+    min-width: 89px;
   }
 
   .btn-toggle:hover {

--- a/src/lib/components/toolbar/ToolBar.svelte
+++ b/src/lib/components/toolbar/ToolBar.svelte
@@ -22,6 +22,9 @@
   }>;
   export let refreshRate: number;
   export let isFrozen: boolean;
+
+  let windowWidth = window.innerWidth;
+  window.onresize = () => (windowWidth = window.innerWidth);
 </script>
 
 <div class="toolbar">
@@ -43,7 +46,9 @@
 
     <RefreshControls bind:refreshRate bind:isFrozen />
 
-    <AppInfo />
+    {#if windowWidth >= 1115}
+      <AppInfo />
+    {/if}
   </div>
 </div>
 


### PR DESCRIPTION
## Description

A (possible) fix for #130, since I quickly found out that to make it work for 1080px width you only have to hide the `AppInfo`. I realize this might not be desirable and an alternative solution would be a hamburger menu, but I am not proficient in svelte enough to make it.

Fixes #130

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

![image](https://github.com/user-attachments/assets/c65b4c69-09ab-4777-b328-b2da0109cf43)
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 