### PR TITLE
feat: add open directory action

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - 🔍 Advanced process search and filtering
 - 📌 Pin important processes
 - 🛠 Process management (kill processes)
+- 📂 Open the directory of the process
 - 🎯 Sort by any column
 - 🔄 Auto-refresh system stats
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -64,3 +64,24 @@ pub async fn kill_process(pid: u32, state: State<'_, AppState>) -> Result<bool, 
     let sys = state.sys.lock().map_err(|e| e.to_string())?;
     Ok(ProcessMonitor::kill_process(&sys, pid))
 }
+
+/// Opens the directory of the process executable in the file explorer
+///
+/// # Arguments
+///
+/// * `pid` - Process ID
+/// * `state` - The application state
+///
+/// # Returns
+///
+/// * `true` if the directory was successfully opened
+/// * `false` otherwise
+///
+/// # Errors
+///
+/// Returns an error string if failed to acquire lock on system state
+#[tauri::command]
+pub async fn open_process_directory(pid: u32, state: State<'_, AppState>) -> Result<bool, String> {
+    let sys = state.sys.lock().map_err(|e| e.to_string())?;
+    Ok(ProcessMonitor::open_process_directory(&sys, pid))
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -33,6 +33,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             commands::get_processes,
             commands::kill_process,
+            commands::open_process_directory,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/lib/components/process/ActionButtons.svelte
+++ b/src/lib/components/process/ActionButtons.svelte
@@ -3,6 +3,7 @@
     faThumbtack,
     faInfoCircle,
     faXmark,
+    faFolderOpen,
   } from "@fortawesome/free-solid-svg-icons";
   import Fa from "svelte-fa";
   import type { Process } from "$lib/types";
@@ -10,6 +11,7 @@
   export let process: Process;
   export let isPinned: boolean;
   export let onTogglePin: (command: string) => void;
+  export let openProcessDirectory: (process: Process) => void;
   export let onShowDetails: (process: Process) => void;
   export let onKillProcess: (process: Process) => void;
 </script>
@@ -23,6 +25,13 @@
       title={isPinned ? "Unpin" : "Pin"}
     >
       <Fa icon={faThumbtack} />
+    </button>
+    <button
+      class="btn-action open-btn"
+      on:click={() => openProcessDirectory(process)}
+      title="Open Directory"
+    >
+      <Fa icon={faFolderOpen} />
     </button>
     <button
       class="btn-action info-btn"
@@ -107,6 +116,14 @@
   .pin-btn.pinned::before {
     background: var(--blue);
     opacity: 0.15;
+  }
+
+  .open-btn {
+    color: var(--green);
+  }
+
+  .open-btn::before {
+    background: var(--green);
   }
 
   .info-btn {

--- a/src/lib/components/process/ProcessRow.svelte
+++ b/src/lib/components/process/ProcessRow.svelte
@@ -10,6 +10,7 @@
   export let onTogglePin: (command: string) => void;
   export let onShowDetails: (process: Process) => void;
   export let onKillProcess: (process: Process) => void;
+  export let openProcessDirectory: (process: Process) => void;
 </script>
 
 <tr class:high-usage={isHighUsage} class:pinned={isPinned}>
@@ -31,6 +32,7 @@
     {process}
     {isPinned}
     {onTogglePin}
+    {openProcessDirectory}
     {onShowDetails}
     {onKillProcess}
   />

--- a/src/lib/components/process/ProcessTable.svelte
+++ b/src/lib/components/process/ProcessTable.svelte
@@ -10,6 +10,7 @@
 
   export let onToggleSort: (field: keyof Process) => void;
   export let onTogglePin: (command: string) => void;
+  export let openProcessDirectory: (process: Process) => void;
   export let onShowDetails: (process: Process) => void;
   export let onKillProcess: (process: Process) => void;
 </script>
@@ -26,6 +27,7 @@
           isHighUsage={process.cpu_usage > 50 ||
             process.memory_usage / (systemStats?.memory_total || 0) > 0.1}
           {onTogglePin}
+          {openProcessDirectory}
           {onShowDetails}
           {onKillProcess}
         />

--- a/src/lib/stores/processes.ts
+++ b/src/lib/stores/processes.ts
@@ -96,6 +96,22 @@ function createProcessStore() {
     }
   };
 
+  const openProcessDirectory = async (process: Process) => {
+    try {
+      const success = await invoke<boolean>("open_process_directory", {
+        pid: process.pid,
+      });
+      if (!success) {
+        throw new Error("Failed to open process directory");
+      }
+    } catch (e: unknown) {
+      update((state) => ({
+        ...state,
+        error: e instanceof Error ? e.message : String(e),
+      }));
+    }
+  };
+
   const toggleSort = (field: keyof Process) => {
     update((state) => ({
       ...state,
@@ -202,6 +218,7 @@ function createProcessStore() {
     setIsLoading,
     getProcesses,
     killProcess,
+    openProcessDirectory,
     toggleSort,
     togglePin,
     setSearchTerm,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -126,6 +126,7 @@
         {pinnedProcesses}
         onToggleSort={processStore.toggleSort}
         onTogglePin={processStore.togglePin}
+        openProcessDirectory={processStore.openProcessDirectory}
         onShowDetails={processStore.showProcessDetails}
         onKillProcess={processStore.confirmKillProcess}
       />


### PR DESCRIPTION
## Description

This PR adds the ability to open a process's executable directory directly from the UI. The implementation includes:

- New Tauri command `open_process_directory` handling cross-platform path opening
- System monitor integration to retrieve process executable paths
- Frontend UI components with a new folder open button (use faFolderOpen icon)
- Process store updates to handle directory opening operations
- Windows/macOS/Linux platform-specific file explorer support

![image](https://github.com/user-attachments/assets/32620e80-7b1a-4e68-a2f1-4061fb051ee3)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Windows - Verify that `explorer` correctly opens the process directory
- [x] macOS - Verify the behavior of the `open` command
- [ ] Linux - Verify the behavior of `xdg-open`
- [x] Test handling of non-existent process paths
- [x] Verify UI button click events and state updates

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes