### PR TITLE
docs: expand README to include package manager installation method section

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Download the latest release from the [releases page](https://github.com/Abdenass
 
 #### Package Managers
 
+Members of the community have kindly published unofficial packages for various platforms and package managers.
+
+Please note, these packages are community-maintained and not officially released, reviewed, or endorsed by NeoHtop.
+We only provide official builds through the GitHub Releases page.
+Since these external packages are managed by third parties, we cannot guarantee their security, integrity, or update frequency.
+
+Please use them at your own discretion.
+
 ##### macOS
 
 Using [Homebrew](https://brew.sh/).


### PR DESCRIPTION
## Description

This pull request adds a `Package Manager` section to the README, so users on different platforms can easily install neohtop without grabbing a binary from the releases page.

If there are any formatting/copy concerns I can change them as needed.

## Type of change

Documentation

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- Tested the outbound links in a markdown rendered
- Got this list from [Repology](https://repology.org/)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings