### PR TITLE
feat: add VirusTotal process scan via SHA-256 hash

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1310,6 +1310,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,13 +1781,16 @@ dependencies = [
 name = "neohtop"
 version = "1.2.0"
 dependencies = [
+ "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-os",
  "tauri-plugin-shell",
+ "tokio",
  "window-vibrancy",
 ]
 
@@ -2458,6 +2478,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 1.0.65",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "slab",
+ "thiserror 1.0.65",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2636,6 +2705,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -2644,11 +2714,16 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -2656,7 +2731,22 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.26.11",
  "windows-registry",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.15",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2664,6 +2754,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -2685,6 +2781,49 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3061,6 +3200,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3573,7 +3718,29 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3779,6 +3946,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -4015,6 +4188,24 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4619,3 +4810,9 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,11 @@ sysinfo = { version = "0.35.2", features = ["disk", "multithread", "network", "s
 tauri-plugin-shell = "2"
 tauri-plugin-os = "2"
 window-vibrancy = "0.5.2"
+sha2 = "0.10"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "macros"] }
 
 [features]
 default = [ "custom-protocol" ]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6,6 +6,7 @@
 
 use crate::monitoring::{ProcessInfo, ProcessMonitor, SystemStats};
 use crate::state::AppState;
+use crate::virustotal::{self, VTReport};
 use tauri::State;
 
 /// Retrieves the current list of processes and system statistics
@@ -64,4 +65,32 @@ pub async fn get_processes(
 pub async fn kill_process(pid: u32, state: State<'_, AppState>) -> Result<bool, String> {
     let sys = state.sys.lock().map_err(|e| e.to_string())?;
     Ok(ProcessMonitor::kill_process(&sys, pid))
+}
+
+/// Computes the SHA-256 hash of the executable for the given PID.
+///
+/// Reads `/proc/<pid>/exe` and returns a 64-character lowercase hex string.
+///
+/// # Errors
+///
+/// Returns an error string if the executable cannot be read
+/// (e.g., permission denied for root-owned processes).
+#[tauri::command]
+pub async fn hash_process(pid: u32) -> Result<String, String> {
+    virustotal::hash_executable(pid)
+}
+
+/// Queries the VirusTotal v3 API for a file by its SHA-256 hash.
+///
+/// # Arguments
+///
+/// * `hash`    - 64-char lowercase hex SHA-256 string
+/// * `api_key` - VirusTotal API key (entered by the user in the UI)
+///
+/// # Errors
+///
+/// Returns a user-friendly error string for auth failures, rate limits, etc.
+#[tauri::command]
+pub async fn check_virustotal_hash(hash: String, api_key: String) -> Result<VTReport, String> {
+    virustotal::check_virustotal(&hash, &api_key).await
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,6 +8,7 @@ mod commands;
 mod monitoring;
 mod state;
 mod ui;
+mod virustotal;
 
 use state::AppState;
 use tauri::Manager;
@@ -38,6 +39,8 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             commands::get_processes,
             commands::kill_process,
+            commands::hash_process,
+            commands::check_virustotal_hash,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/virustotal.rs
+++ b/src-tauri/src/virustotal.rs
@@ -1,0 +1,312 @@
+//! VirusTotal integration
+//!
+//! This module provides:
+//! - SHA-256 hashing of process executables via `/proc/<pid>/exe`
+//! - VirusTotal v3 API querying to get a security verdict
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::io::Read;
+
+/// VirusTotal scan report, serialised to JSON for the frontend
+#[derive(Serialize, Debug, Clone)]
+pub struct VTReport {
+    /// SHA-256 hash of the executable (lowercase hex)
+    pub hash: String,
+    /// Overall verdict
+    pub verdict: String,
+    /// Number of engines that flagged as malicious
+    pub malicious: u64,
+    /// Number of engines that flagged as suspicious
+    pub suspicious: u64,
+    /// Number of engines that returned undetected
+    pub undetected: u64,
+    /// Total number of engines that scanned the file
+    pub total: u64,
+    /// Direct link to the VirusTotal report page
+    pub permalink: String,
+}
+
+/// Reads the process executable at `/proc/<pid>/exe` and computes its SHA-256 hash.
+///
+/// # Errors
+/// Returns an error string if:
+/// - The process executable cannot be read (e.g. permission denied for root processes)
+/// - An I/O error occurs while reading
+pub fn hash_executable(pid: u32) -> Result<String, String> {
+    let exe_path = format!("/proc/{}/exe", pid);
+
+    let mut file = std::fs::File::open(&exe_path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::PermissionDenied {
+            format!(
+                "Permission denied reading process {} executable. \
+                 You can only scan processes you own.",
+                pid
+            )
+        } else {
+            format!("Cannot read process executable (PID {}): {}", pid, e)
+        }
+    })?;
+
+    let mut hasher = Sha256::new();
+    // Read in 64 KiB chunks to avoid loading the whole binary into memory
+    let mut buffer = vec![0u8; 65536];
+    loop {
+        let count = file
+            .read(&mut buffer)
+            .map_err(|e| format!("Read error while hashing PID {}: {}", pid, e))?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+
+    let hash_bytes = hasher.finalize();
+    Ok(format!("{:x}", hash_bytes))
+}
+
+/// Queries the VirusTotal v3 API for a file by its SHA-256 hash.
+///
+/// # Arguments
+/// * `hash`    - SHA-256 hex string (64 chars, lowercase)
+/// * `api_key` - VirusTotal API key
+///
+/// # Errors
+/// Returns a user-friendly error string for common HTTP errors.
+pub async fn check_virustotal(hash: &str, api_key: &str) -> Result<VTReport, String> {
+    if api_key.trim().is_empty() {
+        return Err("Please enter your VirusTotal API key.".to_string());
+    }
+
+    let url = format!("https://www.virustotal.com/api/v3/files/{}", hash);
+
+    let client = reqwest::Client::builder()
+        .user_agent("neohtop/1.2.0")
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+
+    let response = client
+        .get(&url)
+        .header("x-apikey", api_key.trim())
+        .send()
+        .await
+        .map_err(|e| format!("Network error: {}. Check your internet connection.", e))?;
+
+    match response.status().as_u16() {
+        200 => {
+            let json: serde_json::Value = response
+                .json()
+                .await
+                .map_err(|e| format!("Failed to parse VirusTotal response: {}", e))?;
+
+            let stats = &json["data"]["attributes"]["last_analysis_stats"];
+            let malicious = stats["malicious"].as_u64().unwrap_or(0);
+            let suspicious = stats["suspicious"].as_u64().unwrap_or(0);
+            let undetected = stats["undetected"].as_u64().unwrap_or(0);
+            let harmless = stats["harmless"].as_u64().unwrap_or(0);
+            let total = malicious + suspicious + undetected + harmless;
+
+            let verdict = if malicious > 0 {
+                "malicious".to_string()
+            } else if suspicious > 0 {
+                "suspicious".to_string()
+            } else if total > 0 {
+                "clean".to_string()
+            } else {
+                "unknown".to_string()
+            };
+
+            Ok(VTReport {
+                hash: hash.to_string(),
+                verdict,
+                malicious,
+                suspicious,
+                undetected,
+                total,
+                permalink: format!("https://www.virustotal.com/gui/file/{}", hash),
+            })
+        }
+
+        401 => {
+            Err("Invalid API key. Please check your VirusTotal API key and try again.".to_string())
+        }
+
+        404 => {
+            // Hash not in VT database — file has never been submitted
+            Ok(VTReport {
+                hash: hash.to_string(),
+                verdict: "unknown".to_string(),
+                malicious: 0,
+                suspicious: 0,
+                undetected: 0,
+                total: 0,
+                permalink: format!("https://www.virustotal.com/gui/file/{}", hash),
+            })
+        }
+
+        429 => Err(
+            "Rate limit exceeded. VirusTotal free tier allows 4 requests/minute. \
+             Please wait a moment and try again."
+                .to_string(),
+        ),
+
+        status => Err(format!(
+            "VirusTotal API returned unexpected status: HTTP {}",
+            status
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── hash_executable ──────────────────────────────────────────────────────
+
+    /// The current process always owns its own executable, so hashing it must
+    /// succeed and return a valid 64-character lowercase hex SHA-256 digest.
+    #[test]
+    fn test_hash_self_process_succeeds() {
+        let pid = std::process::id();
+        let result = hash_executable(pid);
+        assert!(
+            result.is_ok(),
+            "Hashing own process should succeed: {:?}",
+            result
+        );
+    }
+
+    /// SHA-256 output must be exactly 64 hexadecimal characters (256 bits).
+    #[test]
+    fn test_hash_output_is_valid_sha256_hex() {
+        let pid = std::process::id();
+        let hash = hash_executable(pid).expect("Hashing own process should not fail");
+        assert_eq!(
+            hash.len(),
+            64,
+            "SHA-256 hex digest must be exactly 64 characters"
+        );
+        assert!(
+            hash.chars().all(|c| c.is_ascii_hexdigit()),
+            "SHA-256 hex digest must contain only hex characters [0-9a-f], got: {}",
+            hash
+        );
+        assert!(
+            hash == hash.to_lowercase(),
+            "SHA-256 hex digest must be lowercase, got: {}",
+            hash
+        );
+    }
+
+    /// Hashing the same binary twice must produce identical results
+    /// (deterministic — no salt or timestamp involved).
+    #[test]
+    fn test_hash_is_deterministic() {
+        let pid = std::process::id();
+        let hash_a = hash_executable(pid).expect("First hash should succeed");
+        let hash_b = hash_executable(pid).expect("Second hash should succeed");
+        assert_eq!(
+            hash_a, hash_b,
+            "SHA-256 of the same binary must be identical across calls"
+        );
+    }
+
+    /// PID 0 has no associated executable on Linux; hashing it must return an
+    /// error rather than panicking or producing a garbage result.
+    #[test]
+    fn test_hash_pid_zero_returns_error() {
+        let result = hash_executable(0);
+        assert!(result.is_err(), "Hashing PID 0 should return an error");
+    }
+
+    /// An obviously invalid PID (u32::MAX) must return an error gracefully.
+    #[test]
+    fn test_hash_nonexistent_pid_returns_error() {
+        let result = hash_executable(u32::MAX);
+        assert!(
+            result.is_err(),
+            "Hashing a non-existent PID should return an error"
+        );
+        // Error message should be user-friendly, not a raw OS error code
+        let err = result.unwrap_err();
+        assert!(!err.is_empty(), "Error message must not be empty");
+    }
+
+    // ── check_virustotal (offline / input-validation tests) ──────────────────
+
+    /// An empty API key must be rejected immediately, before any network call
+    /// is attempted.
+    #[tokio::test]
+    async fn test_check_virustotal_empty_api_key_rejected() {
+        let result = check_virustotal("a".repeat(64).as_str(), "").await;
+        assert!(result.is_err(), "Empty API key should be rejected");
+        let err = result.unwrap_err();
+        assert!(
+            err.to_lowercase().contains("api key") || err.to_lowercase().contains("enter"),
+            "Error should mention the API key, got: {}",
+            err
+        );
+    }
+
+    /// A whitespace-only API key must also be rejected before any network call.
+    #[tokio::test]
+    async fn test_check_virustotal_whitespace_api_key_rejected() {
+        let result = check_virustotal("a".repeat(64).as_str(), "   ").await;
+        assert!(
+            result.is_err(),
+            "Whitespace-only API key should be rejected"
+        );
+    }
+
+    // ── VTReport serialisation ────────────────────────────────────────────────
+
+    /// VTReport must be serialisable to JSON (required for the Tauri IPC
+    /// bridge to transmit it to the frontend).
+    #[test]
+    fn test_vt_report_serialises_to_json() {
+        let report = VTReport {
+            hash: "a".repeat(64),
+            verdict: "clean".to_string(),
+            malicious: 0,
+            suspicious: 0,
+            undetected: 72,
+            total: 72,
+            permalink: format!("https://www.virustotal.com/gui/file/{}", "a".repeat(64)),
+        };
+        let json = serde_json::to_string(&report);
+        assert!(
+            json.is_ok(),
+            "VTReport should serialise to JSON without error"
+        );
+        let json_str = json.unwrap();
+        assert!(
+            json_str.contains("\"verdict\""),
+            "JSON must include the verdict field"
+        );
+        assert!(
+            json_str.contains("\"hash\""),
+            "JSON must include the hash field"
+        );
+        assert!(
+            json_str.contains("\"permalink\""),
+            "JSON must include the permalink field"
+        );
+    }
+
+    /// All four verdict strings must round-trip through the VTReport struct.
+    #[test]
+    fn test_vt_report_all_verdicts() {
+        for verdict in &["clean", "malicious", "suspicious", "unknown"] {
+            let report = VTReport {
+                hash: "b".repeat(64),
+                verdict: verdict.to_string(),
+                malicious: 0,
+                suspicious: 0,
+                undetected: 0,
+                total: 0,
+                permalink: String::new(),
+            };
+            assert_eq!(&report.verdict, verdict);
+        }
+    }
+}

--- a/src/lib/components/modals/VirusTotalModal.svelte
+++ b/src/lib/components/modals/VirusTotalModal.svelte
@@ -1,0 +1,551 @@
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { open } from "@tauri-apps/plugin-shell";
+  import { Modal } from "$lib/components";
+  import type { Process, VTReport } from "$lib/types";
+
+  export let show = false;
+  export let process: Process | null = null;
+  export let onClose: () => void;
+
+  // ── State ──────────────────────────────────────────────────────────────────
+  const API_KEY_STORAGE = "neohtop_vt_api_key";
+
+  let apiKey: string = "";
+  let phase: "idle" | "hashing" | "querying" | "done" | "error" = "idle";
+  let hashValue = "";
+  let report: VTReport | null = null;
+  let errorMessage = "";
+
+  // Load saved API key on mount
+  $: if (show) {
+    apiKey = localStorage.getItem(API_KEY_STORAGE) ?? "";
+    // Reset result state when modal is opened for a new process
+    phase = "idle";
+    hashValue = "";
+    report = null;
+    errorMessage = "";
+  }
+
+  // ── Scan flow ──────────────────────────────────────────────────────────────
+  async function startScan() {
+    if (!process) return;
+
+    // Persist API key across sessions
+    if (apiKey.trim()) {
+      localStorage.setItem(API_KEY_STORAGE, apiKey.trim());
+    }
+
+    try {
+      // Step 1: Hash the executable
+      phase = "hashing";
+      errorMessage = "";
+      hashValue = await invoke<string>("hash_process", { pid: process.pid });
+
+      // Step 2: Query VirusTotal
+      phase = "querying";
+      report = await invoke<VTReport>("check_virustotal_hash", {
+        hash: hashValue,
+        apiKey: apiKey.trim(),
+      });
+
+      phase = "done";
+    } catch (err: unknown) {
+      errorMessage = typeof err === "string" ? err : String(err);
+      phase = "error";
+    }
+  }
+
+  function handleClose() {
+    phase = "idle";
+    report = null;
+    errorMessage = "";
+    onClose();
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+  function verdictLabel(v: VTReport["verdict"]): string {
+    const labels: Record<VTReport["verdict"], string> = {
+      clean: "Clean",
+      malicious: "Malicious",
+      suspicious: "Suspicious",
+      unknown: "Not Found",
+    };
+    return labels[v];
+  }
+</script>
+
+<Modal
+  {show}
+  title={`VirusTotal Scan — ${process?.name ?? "Unknown"}`}
+  maxWidth="520px"
+  onClose={handleClose}
+>
+  {#if process}
+    <div class="vt-content">
+      <!-- API Key input -->
+      {#if phase === "idle" || phase === "error"}
+        <div class="api-section">
+          <label for="vt-api-key" class="field-label">
+            VirusTotal API Key
+            <button
+              class="get-key-link"
+              on:click={() => open("https://www.virustotal.com/gui/my-apikey")}
+              title="Get a free API key">Get free key ↗</button
+            >
+          </label>
+          <input
+            id="vt-api-key"
+            type="password"
+            class="api-input"
+            bind:value={apiKey}
+            placeholder="Paste your VirusTotal API key…"
+            on:keydown={(e) => e.key === "Enter" && startScan()}
+          />
+        </div>
+
+        <!-- Process target summary -->
+        <div class="target-info">
+          <span class="target-pid">PID {process.pid}</span>
+          <span class="target-sep">·</span>
+          <span class="target-name">{process.name}</span>
+          {#if process.command}
+            <span class="target-cmd">{process.command.split(" ")[0]}</span>
+          {/if}
+        </div>
+
+        {#if phase === "error"}
+          <div class="error-box">
+            <span class="error-icon">⚠</span>
+            <span>{errorMessage}</span>
+          </div>
+        {/if}
+
+        <div class="actions">
+          <button class="btn-secondary" on:click={handleClose}>Cancel</button>
+          <button
+            class="btn-scan"
+            on:click={startScan}
+            disabled={!apiKey.trim()}
+          >
+            🛡 Scan with VirusTotal
+          </button>
+        </div>
+
+        <!-- Loading states -->
+      {:else if phase === "hashing" || phase === "querying"}
+        <div class="loading-state">
+          <div class="spinner-large"></div>
+          <p class="loading-label">
+            {#if phase === "hashing"}
+              Computing SHA-256 hash of <strong>{process.name}</strong>…
+            {:else}
+              Querying VirusTotal database…
+            {/if}
+          </p>
+          <p class="loading-sub">This may take a few seconds.</p>
+        </div>
+
+        <!-- Result -->
+      {:else if phase === "done" && report}
+        {@const isUnknown = report.verdict === "unknown"}
+
+        <!-- Verdict badge -->
+        <div class="verdict-banner verdict-{report.verdict}">
+          <span class="verdict-icon">
+            {#if report.verdict === "clean"}✅
+            {:else if report.verdict === "malicious"}🚨
+            {:else if report.verdict === "suspicious"}⚠️
+            {:else}❓
+            {/if}
+          </span>
+          <span class="verdict-text">{verdictLabel(report.verdict)}</span>
+          {#if isUnknown}
+            <span class="verdict-sub">File not in VirusTotal database</span>
+          {:else}
+            <span class="verdict-sub">
+              {report.malicious} / {report.total} engines detected a threat
+            </span>
+          {/if}
+        </div>
+
+        <!-- Hash display -->
+        <div class="hash-row">
+          <span class="hash-label">SHA-256</span>
+          <code class="hash-value">{report.hash}</code>
+        </div>
+
+        <!-- Stats table (only if we have data) -->
+        {#if !isUnknown}
+          <div class="stats-grid">
+            <div class="stat-box stat-malicious">
+              <div class="stat-num">{report.malicious}</div>
+              <div class="stat-cap">Malicious</div>
+            </div>
+            <div class="stat-box stat-suspicious">
+              <div class="stat-num">{report.suspicious}</div>
+              <div class="stat-cap">Suspicious</div>
+            </div>
+            <div class="stat-box stat-clean">
+              <div class="stat-num">{report.undetected}</div>
+              <div class="stat-cap">Undetected</div>
+            </div>
+            <div class="stat-box">
+              <div class="stat-num">{report.total}</div>
+              <div class="stat-cap">Total Engines</div>
+            </div>
+          </div>
+        {/if}
+
+        <!-- Actions -->
+        <div class="actions">
+          <button
+            class="btn-secondary"
+            on:click={() => {
+              phase = "idle";
+              report = null;
+            }}
+          >
+            ← Scan Again
+          </button>
+          <button
+            class="btn-vt-link"
+            on:click={() => open(report?.permalink ?? "")}
+          >
+            View on VirusTotal ↗
+          </button>
+          <button class="btn-secondary" on:click={handleClose}>Close</button>
+        </div>
+      {/if}
+    </div>
+  {/if}
+</Modal>
+
+<style>
+  .vt-content {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    font-size: 13px;
+    color: var(--text);
+  }
+
+  /* ── API key ── */
+  .api-section {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .field-label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: var(--subtext0);
+    font-size: 12px;
+    font-weight: 500;
+  }
+
+  .get-key-link {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    color: var(--blue);
+    text-decoration: none;
+    font-size: 11px;
+  }
+
+  .get-key-link:hover {
+    text-decoration: underline;
+  }
+
+  .api-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 12px;
+    background: var(--mantle);
+    border: 1px solid var(--surface1);
+    border-radius: 6px;
+    color: var(--text);
+    font-size: 13px;
+    outline: none;
+    transition: border-color 0.2s;
+  }
+
+  .api-input:focus {
+    border-color: var(--blue);
+  }
+
+  /* ── Target summary ── */
+  .target-info {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    background: var(--surface0);
+    border-radius: 6px;
+    flex-wrap: wrap;
+  }
+
+  .target-pid {
+    color: var(--blue);
+    font-weight: 600;
+    font-size: 12px;
+  }
+
+  .target-sep {
+    color: var(--subtext0);
+  }
+
+  .target-name {
+    color: var(--text);
+    font-weight: 500;
+  }
+
+  .target-cmd {
+    color: var(--subtext0);
+    font-size: 11px;
+    word-break: break-all;
+  }
+
+  /* ── Error box ── */
+  .error-box {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 10px 12px;
+    background: color-mix(in srgb, var(--red) 15%, var(--surface0));
+    border: 1px solid color-mix(in srgb, var(--red) 40%, transparent);
+    border-radius: 6px;
+    color: var(--red);
+    line-height: 1.5;
+  }
+
+  .error-icon {
+    flex-shrink: 0;
+    font-size: 14px;
+  }
+
+  /* ── Loading ── */
+  .loading-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 24px 0;
+  }
+
+  .spinner-large {
+    width: 36px;
+    height: 36px;
+    border: 3px solid var(--surface1);
+    border-top-color: var(--blue);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .loading-label {
+    margin: 0;
+    color: var(--text);
+    font-size: 14px;
+    text-align: center;
+  }
+
+  .loading-sub {
+    margin: 0;
+    color: var(--subtext0);
+    font-size: 12px;
+  }
+
+  /* ── Verdict banner ── */
+  .verdict-banner {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 14px 16px;
+    border-radius: 8px;
+    border: 1px solid;
+  }
+
+  .verdict-clean {
+    background: color-mix(in srgb, var(--green) 12%, var(--surface0));
+    border-color: color-mix(in srgb, var(--green) 35%, transparent);
+  }
+
+  .verdict-malicious {
+    background: color-mix(in srgb, var(--red) 15%, var(--surface0));
+    border-color: color-mix(in srgb, var(--red) 40%, transparent);
+  }
+
+  .verdict-suspicious {
+    background: color-mix(in srgb, var(--yellow) 12%, var(--surface0));
+    border-color: color-mix(in srgb, var(--yellow) 35%, transparent);
+  }
+
+  .verdict-unknown {
+    background: var(--surface0);
+    border-color: var(--surface1);
+  }
+
+  .verdict-icon {
+    font-size: 20px;
+    flex-shrink: 0;
+  }
+
+  .verdict-text {
+    font-size: 16px;
+    font-weight: 700;
+  }
+
+  .verdict-clean .verdict-text {
+    color: var(--green);
+  }
+  .verdict-malicious .verdict-text {
+    color: var(--red);
+  }
+  .verdict-suspicious .verdict-text {
+    color: var(--yellow);
+  }
+  .verdict-unknown .verdict-text {
+    color: var(--subtext0);
+  }
+
+  .verdict-sub {
+    font-size: 12px;
+    color: var(--subtext0);
+    margin-left: auto;
+  }
+
+  /* ── Hash row ── */
+  .hash-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background: var(--mantle);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+
+  .hash-label {
+    flex-shrink: 0;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--subtext0);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .hash-value {
+    font-family: ui-monospace, "Cascadia Code", "Fira Code", monospace;
+    font-size: 11px;
+    color: var(--blue);
+    word-break: break-all;
+    overflow-wrap: anywhere;
+  }
+
+  /* ── Stats grid ── */
+  .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 8px;
+  }
+
+  .stat-box {
+    background: var(--surface0);
+    border-radius: 6px;
+    padding: 10px 8px;
+    text-align: center;
+  }
+
+  .stat-num {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--text);
+  }
+
+  .stat-cap {
+    font-size: 10px;
+    color: var(--subtext0);
+    margin-top: 2px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .stat-malicious .stat-num {
+    color: var(--red);
+  }
+  .stat-suspicious .stat-num {
+    color: var(--yellow);
+  }
+  .stat-clean .stat-num {
+    color: var(--green);
+  }
+
+  /* ── Actions row ── */
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .btn-secondary {
+    padding: 7px 14px;
+    font-size: 13px;
+    color: var(--text);
+    background: var(--surface0);
+    border: 1px solid var(--surface1);
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+
+  .btn-secondary:hover {
+    background: var(--surface1);
+  }
+
+  .btn-scan {
+    padding: 7px 16px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--base);
+    background: var(--blue);
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+
+  .btn-scan:hover {
+    opacity: 0.88;
+  }
+
+  .btn-scan:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .btn-vt-link {
+    padding: 7px 14px;
+    font-size: 13px;
+    color: var(--teal);
+    background: color-mix(in srgb, var(--teal) 12%, var(--surface0));
+    border: 1px solid color-mix(in srgb, var(--teal) 30%, transparent);
+    border-radius: 6px;
+    text-decoration: none;
+    transition: background 0.15s;
+  }
+
+  .btn-vt-link:hover {
+    background: color-mix(in srgb, var(--teal) 20%, var(--surface0));
+  }
+</style>

--- a/src/lib/components/modals/index.ts
+++ b/src/lib/components/modals/index.ts
@@ -1,3 +1,4 @@
 export { default as Modal } from "./Modal.svelte";
 export { default as ProcessDetailsModal } from "./ProcessDetailsModal.svelte";
 export { default as KillProcessModal } from "./KillProcessModal.svelte";
+export { default as VirusTotalModal } from "./VirusTotalModal.svelte";

--- a/src/lib/components/process/ActionButtons.svelte
+++ b/src/lib/components/process/ActionButtons.svelte
@@ -3,6 +3,7 @@
     faThumbtack,
     faInfoCircle,
     faXmark,
+    faShield,
   } from "@fortawesome/free-solid-svg-icons";
   import Fa from "svelte-fa";
   import type { Process } from "$lib/types";
@@ -12,6 +13,7 @@
   export let onTogglePin: (command: string) => void;
   export let onShowDetails: (process: Process) => void;
   export let onKillProcess: (process: Process) => void;
+  export let onScanProcess: (process: Process) => void;
 </script>
 
 <td class="col-actions">
@@ -30,6 +32,13 @@
       title="Show Details"
     >
       <Fa icon={faInfoCircle} />
+    </button>
+    <button
+      class="btn-action scan-btn"
+      on:click={() => onScanProcess(process)}
+      title="Scan with VirusTotal"
+    >
+      <Fa icon={faShield} />
     </button>
     <button
       class="btn-action kill-btn"
@@ -54,7 +63,7 @@
     z-index: 2;
     background: var(--base);
     border-left: 1px solid var(--surface0);
-    width: 120px;
+    width: 148px;
   }
 
   .action-buttons {
@@ -129,6 +138,14 @@
 
   .kill-btn:hover::before {
     opacity: 1;
+  }
+
+  .scan-btn {
+    color: var(--teal);
+  }
+
+  .scan-btn::before {
+    background: var(--teal);
   }
 
   .btn-action:hover {

--- a/src/lib/components/process/ProcessRow.svelte
+++ b/src/lib/components/process/ProcessRow.svelte
@@ -10,6 +10,7 @@
   export let onTogglePin: (command: string) => void;
   export let onShowDetails: (process: Process) => void;
   export let onKillProcess: (process: Process) => void;
+  export let onScanProcess: (process: Process) => void;
 </script>
 
 <tr class:high-usage={isHighUsage} class:pinned={isPinned}>
@@ -33,6 +34,7 @@
     {onTogglePin}
     {onShowDetails}
     {onKillProcess}
+    {onScanProcess}
   />
 </tr>
 

--- a/src/lib/components/process/ProcessTable.svelte
+++ b/src/lib/components/process/ProcessTable.svelte
@@ -12,6 +12,7 @@
   export let onTogglePin: (command: string) => void;
   export let onShowDetails: (process: Process) => void;
   export let onKillProcess: (process: Process) => void;
+  export let onScanProcess: (process: Process) => void;
 </script>
 
 <div class="table-container">
@@ -28,6 +29,7 @@
           {onTogglePin}
           {onShowDetails}
           {onKillProcess}
+          {onScanProcess}
         />
       {/each}
     </tbody>

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -113,3 +113,20 @@ export interface SortConfig {
   field: keyof Process;
   direction: "asc" | "desc";
 }
+
+export interface VTReport {
+  /** SHA-256 hex hash of the executable */
+  hash: string;
+  /** Overall verdict: clean | malicious | suspicious | unknown */
+  verdict: "clean" | "malicious" | "suspicious" | "unknown";
+  /** Number of AV engines that flagged as malicious */
+  malicious: number;
+  /** Number of AV engines that flagged as suspicious */
+  suspicious: number;
+  /** Number of AV engines that returned undetected */
+  undetected: number;
+  /** Total number of AV engines in the scan */
+  total: number;
+  /** Direct link to the VirusTotal report */
+  permalink: string;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,6 +8,7 @@
     ProcessTable,
     ProcessDetailsModal,
     KillProcessModal,
+    VirusTotalModal,
   } from "$lib/components/index";
   import { themeStore, settingsStore, processStore } from "$lib/stores/index";
   import { column_definitions } from "$lib/definitions/columns";
@@ -35,6 +36,20 @@
   let lastProcessCount = 0;
   let cachedFilteredProcesses: Process[] = [];
   let cachedSortedProcesses: Process[] = [];
+
+  // VirusTotal scan modal state
+  let showVTModal = false;
+  let vtProcess: Process | null = null;
+
+  function openVTScan(process: Process) {
+    vtProcess = process;
+    showVTModal = true;
+  }
+
+  function closeVTScan() {
+    showVTModal = false;
+    vtProcess = null;
+  }
 
   // Initialize filters object for the new FilterToggle
   let filters = {
@@ -167,6 +182,7 @@
         onTogglePin={processStore.togglePin}
         onShowDetails={processStore.showProcessDetails}
         onKillProcess={processStore.confirmKillProcess}
+        onScanProcess={openVTScan}
       />
     </main>
   </div>
@@ -187,6 +203,8 @@
   onClose={processStore.closeConfirmKill}
   onConfirm={processStore.handleConfirmKill}
 />
+
+<VirusTotalModal show={showVTModal} process={vtProcess} onClose={closeVTScan} />
 
 <style>
   :global(:root) {


### PR DESCRIPTION
Adds on-demand security scanning for any running process by:
- Hashing the process executable (SHA-256 via /proc/<pid>/exe)
- Querying the VirusTotal v3 API with the computed hash
- Displaying a colour-coded verdict in a dedicated modal

## Backend (Rust)
- New `virustotal` module with `hash_executable()` and `check_virustotal()` functions
- Two new Tauri commands: `hash_process` and `check_virustotal_hash`
- Graceful error handling: permission denied, rate limits (429), invalid API key (401), file not in database (404)
- Reads executable in 64 KiB chunks to avoid loading large binaries fully into memory

## Frontend (Svelte)
- New `VirusTotalModal` component with three phases: idle → loading (hashing / querying) → result
- Colour-coded verdict badge using existing CSS palette: green (clean), red (malicious), yellow (suspicious), grey (unknown)
- SHA-256 hash display + per-engine stats grid
- API key persisted to localStorage; never sent to the backend at rest
- "View on VirusTotal" opens the system browser via the shell plugin
- New teal shield button added to per-row action buttons

## Tests
- 9 new unit tests covering: SHA-256 format, determinism, invalid PIDs, empty/whitespace API key rejection, VTReport JSON serialisation, and all four verdict values
- All 13 tests (including pre-existing ones) pass