### PR TITLE
Ship a universal macOS binary to fix the Rosetta deprecation warning

### DIFF
--- a/.github/workflows/macos-nightly.yml
+++ b/.github/workflows/macos-nightly.yml
@@ -1,4 +1,4 @@
-name: MacOS (Intel/Apple Silicon) Nightly Build
+name: MacOS (Universal) Nightly Build
 
 on:
   workflow_dispatch:
@@ -48,58 +48,31 @@ jobs:
       - name: Build Frontend
         run: npm run build
         
-      - name: Build for Intel Mac
+      - name: Build Universal macOS App
         run: |
-          echo "Building for Intel Mac..."
-          npm run tauri build -- --target x86_64-apple-darwin --bundles dmg --config "{\"bundle\":{\"macOS\":{\"signingIdentity\": \"Developer ID Application: Abdenasser Elidrissi (785JV74B9Y)\"}}}"
-          # Rename the Intel build and store the filename
-          cd src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/
-          for f in *.dmg; do 
-            mv "$f" "intel-$f"
-            echo "INTEL_DMG_PATH=src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/intel-$f" >> $GITHUB_ENV
+          echo "Building universal macOS app (Intel + Apple Silicon)..."
+          npm run tauri build -- --target universal-apple-darwin --bundles dmg --config "{\"bundle\":{\"macOS\":{\"signingIdentity\": \"Developer ID Application: Abdenasser Elidrissi (785JV74B9Y)\"}}}"
+          # Store the universal build filename
+          cd src-tauri/target/universal-apple-darwin/release/bundle/dmg/
+          for f in *.dmg; do
+            echo "UNIVERSAL_DMG_PATH=src-tauri/target/universal-apple-darwin/release/bundle/dmg/$f" >> $GITHUB_ENV
           done
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          
-      - name: Build for Apple Silicon
-        run: |
-          echo "Building for aarch64..."
-          npm run tauri build -- --target aarch64-apple-darwin --bundles dmg --config "{\"bundle\":{\"macOS\":{\"signingIdentity\": \"Developer ID Application: Abdenasser Elidrissi (785JV74B9Y)\"}}}"
-          # Rename the Apple Silicon build and store the filename
-          cd src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/
-          for f in *.dmg; do 
-            mv "$f" "silicon-$f"
-            echo "SILICON_DMG_PATH=src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/silicon-$f" >> $GITHUB_ENV
-          done
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          
+
       - name: Get version from package.json
         id: version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
-      - name: Upload Intel Build to Release
+      - name: Upload Universal Build to Release
         if: github.event.inputs.release_upload_url != ''
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         with:
           upload_url: ${{ github.event.inputs.release_upload_url }}
-          asset_path: ${{ env.INTEL_DMG_PATH }}
-          asset_name: intel-NeoHtop_${{ steps.version.outputs.version }}_x64.dmg
-          asset_content_type: application/x-apple-diskimage
-
-      - name: Upload Silicon Build to Release
-        if: github.event.inputs.release_upload_url != ''
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
-        with:
-          upload_url: ${{ github.event.inputs.release_upload_url }}
-          asset_path: ${{ env.SILICON_DMG_PATH }}
-          asset_name: silicon-NeoHtop_${{ steps.version.outputs.version }}_aarch64.dmg
+          asset_path: ${{ env.UNIVERSAL_DMG_PATH }}
+          asset_name: NeoHtop_${{ steps.version.outputs.version }}_universal.dmg
           asset_content_type: application/x-apple-diskimage

--- a/docs/index.html
+++ b/docs/index.html
@@ -164,18 +164,11 @@
                 alt="Notarized by Apple">
             </div>
             <div class="platform-options">
-              <a href="" class="download-button macos" data-type="macos-intel" data-version="latest">
-                <span class="icon">💻</span>
-                <div class="button-text">
-                  <span class="primary">Intel Chip</span>
-                  <span class="secondary">macOS 10.15 or later</span>
-                </div>
-              </a>
-              <a href="" class="download-button macos" data-type="macos-silicon" data-version="latest">
+              <a href="" class="download-button macos" data-type="macos-universal" data-version="latest">
                 <span class="icon">🍎</span>
                 <div class="button-text">
-                  <span class="primary">Apple Silicon</span>
-                  <span class="secondary">macOS 11.0 or later</span>
+                  <span class="primary">Universal (Intel & Apple Silicon)</span>
+                  <span class="secondary">macOS 10.15 or later</span>
                 </div>
               </a>
             </div>
@@ -448,8 +441,8 @@
             <span class="faq-icon">⌄</span>
           </button>
           <div class="faq-answer">
-            <p>NeoHtop supports macOS 10.15 (Catalina) and newer versions. It's optimized for both Intel and Apple
-              Silicon Macs, with native support for both architectures.</p>
+            <p>NeoHtop supports macOS 10.15 (Catalina) and newer versions. It ships as a single universal binary
+              that runs natively on both Intel and Apple Silicon Macs.</p>
           </div>
         </div>
 

--- a/docs/main.js
+++ b/docs/main.js
@@ -73,8 +73,7 @@ async function updateVersion() {
 
 function updateDownloadLinks(versionNumber) {
   const platformUrls = {
-    'macos-intel': `intel-NeoHtop_${versionNumber}_x64.dmg`,
-    'macos-silicon': `silicon-NeoHtop_${versionNumber}_aarch64.dmg`,
+    'macos-universal': `NeoHtop_${versionNumber}_universal.dmg`,
     'windows': `NeoHtop_${versionNumber}_x64.exe`,
     'linux-deb-x64': `NeoHtop_${versionNumber}_x86_64.deb`,
     'linux-appimage-x64': `NeoHtop_${versionNumber}_x86_64.AppImage`,


### PR DESCRIPTION
## Problem
On Apple Silicon Macs, macOS now shows a notification that NeoHtop "includes a component that will not open in macOS 28":

> **App Update Required**
> This version of "NeoHtop" includes a component that will not open in macOS 28, the next major release. An update may be available on the developer's website.

This is the Rosetta deprecation warning. The releases currently ship two separate single-arch DMGs (`intel-NeoHtop_*_x64.dmg` and `silicon-NeoHtop_*_aarch64.dmg`), and it's easy to end up with the Intel build on an ARM Mac — where it runs translated under Rosetta, which Apple is retiring after macOS 27.

## Fix
Build one **universal** DMG (`--target universal-apple-darwin`) instead of separate Intel and Apple Silicon DMGs, so the app always runs natively on both architectures:

- `.github/workflows/macos-nightly.yml` now builds and uploads a single `NeoHtop_<version>_universal.dmg`. Signing/notarization is unchanged, and both rustup targets were already installed in the workflow (required for the universal build).
- The download page (`docs/`) offers one "Universal (Intel & Apple Silicon)" button instead of separate Intel/Silicon buttons, and the FAQ mentions the universal binary.

Verified the download page locally: it renders the single button and builds the correct asset URL (`https://github.com/Abdenasser/neohtop/releases/download/v<version>/NeoHtop_<version>_universal.dmg`).

## Note for merging
The docs site links the latest release by asset name, so the macOS download button will point at `NeoHtop_<version>_universal.dmg` as soon as this merges — best to cut a release shortly after merging so the asset exists. (Alternatively the old asset names could be uploaded alongside for one transition release.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)